### PR TITLE
Install `future` dependency automatically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='ballpark',
     license='ISC',
     packages=find_packages(),
     keywords='human numbers format notation scientific engineering',
-    install_requires=[],
+    install_requires=['future'],
     test_suite='ballpark.tests',
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Installing ballpark with pip doesnt install the `future` dependency, tested on raspbian.

```
$ federico@raspbian ~ ❯❯❯ python --version                                                                 ⏎
Python 2.7.9
federico@raspbian ~ ❯❯❯ sudo pip install ballpark
Collecting ballpark
Installing collected packages: ballpark
Successfully installed ballpark-1.4.0
federico@raspbian ~ ❯❯❯ python
Python 2.7.9 (default, Sep 17 2016, 20:26:04)
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from ballpark import human, scientific, engineering, business, ballpark
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/ballpark/__init__.py", line 1, in <module>
    from . import notation, shortcuts, statistics, tests
  File "/usr/local/lib/python2.7/dist-packages/ballpark/notation.py", line 6, in <module>
    from .statistics import median
  File "/usr/local/lib/python2.7/dist-packages/ballpark/statistics.py", line 6, in <module>
    from .utils import isnan, reject
  File "/usr/local/lib/python2.7/dist-packages/ballpark/utils.py", line 4, in <module>
    import builtins
ImportError: No module named builtins
federico@raspbian ~ ❯❯❯ sudo pip install future
Collecting future
  Downloading future-0.16.0.tar.gz (824kB)
    100% |████████████████████████████████| 829kB 202kB/s
Building wheels for collected packages: future
  Running setup.py bdist_wheel for future ... done
  Stored in directory: /root/.cache/pip/wheels/c2/50/7c/0d83b4baac4f63ff7a765bd16390d2ab43c93587fac9d6017a
Successfully built future
Installing collected packages: future
Successfully installed future-0.16.0
federico@raspbian ~ ❯❯❯ python
Python 2.7.9 (default, Sep 17 2016, 20:26:04)
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import ballpark
>>> from ballpark import human, scientific, engineering, business, ballpark
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name human
>>> from ballpark import business
>>> business([11234.22, 233000.55, 1175125.2])
['11K', '233K', '1,180K']
```